### PR TITLE
refactor(@app/services):rector option params at service

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { ViewportScroller } from '@angular/common';
 import { Component, HostListener } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
 
 @Component({
   selector: 'app-root',

--- a/src/app/core/dashboard.service.ts
+++ b/src/app/core/dashboard.service.ts
@@ -10,9 +10,13 @@ export class DashboardService {
   constructor(private _httpClient: HttpClient) {}
 
   allOrders(numOfPadge: number = 1): Observable<any> {
-    return this._httpClient.get(`${baseUrl}/api/v1/orders?page=${numOfPadge}`);
+    return this._httpClient.get(`${baseUrl}/api/v1/orders`, {
+      params: { page: numOfPadge },
+    });
   }
   allUsers(numOfPadge: number = 1): Observable<any> {
-    return this._httpClient.get(`${baseUrl}/api/v1/users?page=${numOfPadge}`);
+    return this._httpClient.get(`${baseUrl}/api/v1/users`, {
+      params: { page: numOfPadge },
+    });
   }
 }

--- a/src/app/core/products-data.service.ts
+++ b/src/app/core/products-data.service.ts
@@ -9,9 +9,9 @@ import { baseUrl } from '../shared/paseApi';
 export class ProductsDataService {
   constructor(private _httpClient: HttpClient) {}
   allProducts(numOfPadge: number = 1): Observable<any> {
-    return this._httpClient.get(
-      `${baseUrl}/api/v1/products?page=${numOfPadge}`
-    );
+    return this._httpClient.get(`${baseUrl}/api/v1/products`, {
+      params: { page: numOfPadge },
+    });
   }
 
   lengthProducts: BehaviorSubject<number> = new BehaviorSubject(0);
@@ -26,7 +26,9 @@ export class ProductsDataService {
     return this._httpClient.get(`${baseUrl}/api/v1/categories/${id}`);
   }
   allBrand(numOfPadge: number = 1): Observable<any> {
-    return this._httpClient.get(`${baseUrl}/api/v1/brands?page=${numOfPadge}`);
+    return this._httpClient.get(`${baseUrl}/api/v1/brands`, {
+      params: { page: numOfPadge },
+    });
   }
   specificBrand(id: string | null): Observable<any> {
     return this._httpClient.get(`${baseUrl}/api/v1/brands/${id}`);


### PR DESCRIPTION
1 refactor params at services
1.1 replace static  params with dynamic params

-  old syntax
  allBrand(numOfPadge: number = 1): Observable<any> {
    return this._httpClient.get(`${baseUrl}/api/v1/brands?page=${numOfPadge}`);
  }

  -  new syntax 
  allBrand(numOfPadge: number = 1): Observable<any> {
    return this._httpClient.get(`${baseUrl}/api/v1/brands`, {
      params: { page: numOfPadge },
    });
  }